### PR TITLE
Fix runtime path resolution to support global binary installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.3
+- Fixed incorrect path resolution in installed CLI binary
+    - Replaced project_root() logic with a dynamic $HOME/.dotmanz path resolver
+- Added fallback support for DOTMANZ_HOME environment variable
+    - Useful for sandboxing or testing in alternate directories
+- Ensured dot binary runs reliably after installation regardless of working directory
+    - Updated utils.rs to use the dirs crate for cross-platform home directory resolution
+- Improved consistency between install script and binary behavior
+    - Strengthened long-term portability and modular ZSH loading
+
 ---
+
 ## v2.0.2
 
 - Build universal macOS binary using GitHub Actions (`aarch64` + `x86_64`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }   # Command-line interface
-dirs = "5.0"                                        # Cross-platform user dirs
+dirs = "5.0.1"                                        # Cross-platform user dirs
 regex = "1.10"                                      # For editing lines in .zshrc
 walkdir = "2.5"                                     # Traverse ~/.dotmanz/zsh/
 anyhow = "1.0"                                      # Ergonomic error handling

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,20 +1,25 @@
 use std::env;
 use std::path::PathBuf;
 
-pub fn project_root() -> PathBuf {
-    let exe_path = env::current_exe().expect("Failed to get current exe path");
-    exe_path
-        .parent()         // /target/debug/
-        .and_then(|p| p.parent())   // /target/
-        .and_then(|p| p.parent())   // /dotmanz/
-        .map(|p| p.to_path_buf())
-        .expect("Failed to resolve project root")
+pub fn install_root() -> PathBuf {
+    dirs::home_dir()
+        .expect("Could not find home directory")
+        .join(".dotmanz")
 }
 
 pub fn get_local_zsh_dir() -> PathBuf {
-    project_root().join("zsh")
+    install_root().join("zsh")
 }
 
 pub fn get_local_zshrc_path() -> PathBuf {
-    project_root().join(".zshrc")
+    dirs::home_dir()
+        .expect("Could not find home directory")
+        .join(".zshrc")
+}
+
+pub fn install_root() -> PathBuf {
+    if let Ok(path) = env::var("DOTMANZ_HOME") {
+        return PathBuf::from(path);
+    }
+    dirs::home_dir().expect("Could not find home dir").join(".dotmanz")
 }


### PR DESCRIPTION
Currently, the `dot` CLI binary assumes it is executed from the root of the source repository and tries to resolve paths like `./zsh` and `./.zshrc` relative to the executable location.
This breaks when the tool is installed globally using an install script, as the binary is placed in `~/.dotmanz` and symlinked to `/usr/local/bin`.
This issue proposes to:
- Use `$HOME/.dotmanz` as the standardized install/runtime path for `zsh` modules and `.zshrc`
- Add support for `DOTMANZ_HOME` environment variable to override path for testing or sandboxing
- Ensure consistency between the install script and the Rust binary logic
Fixing this will make the tool work reliably after installation, regardless of the working directory or context.

Closes #
