### PR TITLE
Error: install_root is defined multiple times

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,9 +2,10 @@ use std::env;
 use std::path::PathBuf;
 
 pub fn install_root() -> PathBuf {
-    dirs::home_dir()
-        .expect("Could not find home directory")
-        .join(".dotmanz")
+    if let Ok(path) = env::var("DOTMANZ_HOME") {
+        return PathBuf::from(path);
+    }
+    dirs::home_dir().expect("Could not find home dir").join(".dotmanz")
 }
 
 pub fn get_local_zsh_dir() -> PathBuf {
@@ -17,9 +18,4 @@ pub fn get_local_zshrc_path() -> PathBuf {
         .join(".zshrc")
 }
 
-pub fn install_root() -> PathBuf {
-    if let Ok(path) = env::var("DOTMANZ_HOME") {
-        return PathBuf::from(path);
-    }
-    dirs::home_dir().expect("Could not find home dir").join(".dotmanz")
-}
+


### PR DESCRIPTION
The error and warnings are clear and easy to fix. Here's the breakdown:
---
 ❌ Error: `install_root` is defined multiple times
1. **Unused import in `add.rs`**:
```rust
use crate::commands::refresh;
```
If `refresh` is not being used in that file, **remove the line**.
2. **Unused import in `edit.rs`**:
```rust
use std::path::{Path, PathBuf};
```
If `PathBuf` isn’t used, change it to:
```rust
use std::path::Path;
```
Or delete both if unused.

Closes #
