### PR TITLE
Update install.sh to support prebuilt dotmanz binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,34 +8,37 @@ YELLOW="\033[1;33m"
 RED="\033[0;31m"
 RESET="\033[0m"
 
-# Define paths
+# Paths
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="$HOME/.dotmanz"
-INSTALL_BIN="$INSTALL_DIR/dot"
-SYSTEM_BIN="/usr/local/bin/dot"
+INSTALL_BIN="$INSTALL_DIR/dotmanz"
+SYSTEM_BIN="/usr/local/bin/dotmanz"
 ZSHRC="$HOME/.zshrc"
 
-# Build binary
-echo -e "${YELLOW}Building release binary...${RESET}"
-cp "$REPO_DIR/dot" "$INSTALL_BIN"
-
-
-# Create install directory
+# Step 1: Prepare target
 mkdir -p "$INSTALL_DIR"
-cp ./dot "$INSTALL_DIR/"
+
+# Step 2: Copy binary
+if [[ ! -f "$REPO_DIR/dotmanz" ]]; then
+  echo -e "${RED}Error:${RESET} dotmanz binary not found in $REPO_DIR"
+  exit 1
+fi
+
+echo -e "${YELLOW}Installing dotmanz binary...${RESET}"
+cp "$REPO_DIR/dotmanz" "$INSTALL_BIN"
 chmod +x "$INSTALL_BIN"
 
-# Copy zsh modules
+# Step 3: Copy ZSH modules
 echo -e "${YELLOW}Copying ZSH modules...${RESET}"
 cp -r "$REPO_DIR/zsh" "$INSTALL_DIR/zsh"
 
-# Symlink to /usr/local/bin
+# Step 4: Link to /usr/local/bin
 echo -e "${YELLOW}Linking CLI to /usr/local/bin...${RESET}"
 sudo ln -sf "$INSTALL_BIN" "$SYSTEM_BIN"
 
-# Patch .zshrc
-SOURCE_LINE='for f in $HOME/.dotmanz/zsh/*.zsh; do source "$f"; done'
+# Step 5: Patch .zshrc to source from ~/.dotmanz/zsh
 HEADER_LINE="# dotmanz module loader"
+SOURCE_LINE='for f in $HOME/.dotmanz/zsh/*.zsh; do source "$f"; done'
 
 if grep -Fq "$SOURCE_LINE" "$ZSHRC"; then
   echo -e "${YELLOW}Notice:${RESET} .zshrc already configured."
@@ -46,6 +49,6 @@ else
 fi
 
 # Done
-echo -e "\n${GREEN} dotmanz installed successfully!${RESET}"
+echo -e "\n${GREEN}dotmanz installed successfully!${RESET}"
 echo -e "${YELLOW}Run:${RESET} source ~/.zshrc"
-echo -e "${YELLOW}Try:${RESET} dot list"
+echo -e "${YELLOW}Try:${RESET} dotmanz list"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,15 +1,9 @@
-use std::env;
 use std::path::PathBuf;
 
-pub fn install_root() -> PathBuf {
-    if let Ok(path) = env::var("DOTMANZ_HOME") {
-        return PathBuf::from(path);
-    }
-    dirs::home_dir().expect("Could not find home dir").join(".dotmanz")
-}
-
 pub fn get_local_zsh_dir() -> PathBuf {
-    install_root().join("zsh")
+    dirs::home_dir()
+        .expect("Could not find home directory")
+        .join(".dotmanz/zsh")
 }
 
 pub fn get_local_zshrc_path() -> PathBuf {
@@ -17,5 +11,3 @@ pub fn get_local_zshrc_path() -> PathBuf {
         .expect("Could not find home directory")
         .join(".zshrc")
 }
-
-


### PR DESCRIPTION
Now that we are packaging `dotmanz` as a precompiled Rust binary (`dotmanz` instead of `dot`), the `install.sh` script must be updated to:
- Use `dotmanz` as the binary name (no collision with Homebrew's `dot`)
- Copy the binary and zsh modules to `~/.dotmanz`
- Symlink the binary to `/usr/local/bin/dotmanz`
- Patch `.zshrc` to source all modules from `~/.dotmanz/zsh` only if not already present
- Provide clearer status and error output
- [x] Rename binary reference from `dot` to `dotmanz`
- [x] Add existence check for `dotmanz` before attempting copy
- [x] Make output messages more readable and reliable
- [x] Use consistent directory resolution and zshrc patching
A polished installation experience using GitHub Releases `.tar.gz` file, making installation of `dotmanz` seamless across systems.

Closes #39