### PR TITLE
Fix cargo edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.4
+
+- Added `dotmanz completions` subcommand
+  - Supports ZSH completion script generation (`dotmanz completions zsh`)
+  - Adds tab-completion for commands and flags
+- Shell completion auto-installed during setup
+  - `_dotmanz` is bundled in the release archive under `completions/`
+  - `install.sh` copies it to `~/.zsh/completions` and patches `.zshrc`
+- Modularized GitHub Actions into 3 workflows:
+  - `build.yml`: Compiles and audits every commit
+  - `test.yml`: Runs `cargo test`, validates install.sh
+  - `release.yml`: Builds universal binary and uploads `.tar.gz` on tags
+- New release archive includes:
+  - `dotmanz` binary
+  - `zsh/` module folder
+  - `completions/_dotmanz` for ZSH shell completion
+  - `install.sh` for seamless setup
+-  Cleanup: Removed legacy `package.yml` workflow
+
+---
+
 ## v2.0.3
 - Fixed incorrect path resolution in installed CLI binary
     - Replaced project_root() logic with a dynamic $HOME/.dotmanz path resolver

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dotmanz"
 version = "2.0.4"
-edition = "2025"
+edition = "2021"
 authors = ["Ayush Poudel ayushpoudel2003@gmail.com"]
 description = "dotmanz CLI – manage modular ZSH configs from the command line."
 license = "MIT"


### PR DESCRIPTION
Run cargo test
error: failed to parse manifest at `/Users/runner/work/dotmanz/dotmanz/Cargo.toml`
Caused by:
  failed to parse the `edition` key
Caused by:
  this version of Cargo is older than the `2025` edition, and only supports `2015`, `2018`, `2021`, and `2024` editions.
  **Cargo edition should have never changed to 2025**

Closes #54